### PR TITLE
Migrate to ethjs

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2675,6 +2675,40 @@
         }
       }
     },
+    "ethjs": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/ethjs/-/ethjs-0.3.0.tgz",
+      "integrity": "sha1-WaSp/ccrTI89OpifWTcoeqQRcxI=",
+      "requires": {
+        "bn.js": "4.11.6",
+        "ethjs-abi": "0.2.0",
+        "ethjs-contract": "0.1.9",
+        "ethjs-filter": "0.1.5",
+        "ethjs-provider-http": "0.1.6",
+        "ethjs-query": "0.3.1",
+        "ethjs-unit": "0.1.6",
+        "ethjs-util": "0.1.3",
+        "js-sha3": "0.5.5",
+        "number-to-bn": "1.7.0"
+      },
+      "dependencies": {
+        "bn.js": {
+          "version": "4.11.6",
+          "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.11.6.tgz",
+          "integrity": "sha1-UzRK2xRhehP26N0s4okF0cC6MhU="
+        },
+        "ethjs-abi": {
+          "version": "0.2.0",
+          "resolved": "https://registry.npmjs.org/ethjs-abi/-/ethjs-abi-0.2.0.tgz",
+          "integrity": "sha1-0+LCIQEVIPxJm3FoIDbBT8wvWyU=",
+          "requires": {
+            "bn.js": "4.11.6",
+            "js-sha3": "0.5.5",
+            "number-to-bn": "1.7.0"
+          }
+        }
+      }
+    },
     "ethjs-abi": {
       "version": "0.1.8",
       "resolved": "https://registry.npmjs.org/ethjs-abi/-/ethjs-abi-0.1.8.tgz",
@@ -2690,6 +2724,118 @@
           "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.11.6.tgz",
           "integrity": "sha1-UzRK2xRhehP26N0s4okF0cC6MhU="
         }
+      }
+    },
+    "ethjs-contract": {
+      "version": "0.1.9",
+      "resolved": "https://registry.npmjs.org/ethjs-contract/-/ethjs-contract-0.1.9.tgz",
+      "integrity": "sha1-HCdmiWpW1H7B1tZhgpxJzDilUgo=",
+      "requires": {
+        "ethjs-abi": "0.2.0",
+        "ethjs-filter": "0.1.5",
+        "ethjs-util": "0.1.3",
+        "js-sha3": "0.5.5"
+      },
+      "dependencies": {
+        "bn.js": {
+          "version": "4.11.6",
+          "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.11.6.tgz",
+          "integrity": "sha1-UzRK2xRhehP26N0s4okF0cC6MhU="
+        },
+        "ethjs-abi": {
+          "version": "0.2.0",
+          "resolved": "https://registry.npmjs.org/ethjs-abi/-/ethjs-abi-0.2.0.tgz",
+          "integrity": "sha1-0+LCIQEVIPxJm3FoIDbBT8wvWyU=",
+          "requires": {
+            "bn.js": "4.11.6",
+            "js-sha3": "0.5.5",
+            "number-to-bn": "1.7.0"
+          }
+        }
+      }
+    },
+    "ethjs-filter": {
+      "version": "0.1.5",
+      "resolved": "https://registry.npmjs.org/ethjs-filter/-/ethjs-filter-0.1.5.tgz",
+      "integrity": "sha1-ARKvYBfCRnfjK4/esg5hlgGbdZg="
+    },
+    "ethjs-format": {
+      "version": "0.2.4",
+      "resolved": "https://registry.npmjs.org/ethjs-format/-/ethjs-format-0.2.4.tgz",
+      "integrity": "sha1-W7vESlrSTmirOTMS/5A5pztlv4E=",
+      "requires": {
+        "bn.js": "4.11.6",
+        "ethjs-schema": "0.1.9",
+        "ethjs-util": "0.1.3",
+        "is-hex-prefixed": "1.0.0",
+        "number-to-bn": "1.7.0",
+        "strip-hex-prefix": "1.0.0"
+      },
+      "dependencies": {
+        "bn.js": {
+          "version": "4.11.6",
+          "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.11.6.tgz",
+          "integrity": "sha1-UzRK2xRhehP26N0s4okF0cC6MhU="
+        }
+      }
+    },
+    "ethjs-provider-http": {
+      "version": "0.1.6",
+      "resolved": "https://registry.npmjs.org/ethjs-provider-http/-/ethjs-provider-http-0.1.6.tgz",
+      "integrity": "sha1-HsXZtL4lfvHValALIqdBmF6IlCA=",
+      "requires": {
+        "xhr2": "0.1.3"
+      },
+      "dependencies": {
+        "xhr2": {
+          "version": "0.1.3",
+          "resolved": "https://registry.npmjs.org/xhr2/-/xhr2-0.1.3.tgz",
+          "integrity": "sha1-y/xHWaabSoiOeM9PILBRA4dXvRE="
+        }
+      }
+    },
+    "ethjs-query": {
+      "version": "0.3.1",
+      "resolved": "https://registry.npmjs.org/ethjs-query/-/ethjs-query-0.3.1.tgz",
+      "integrity": "sha1-rtW2C9t+c62DHRIYyLBnMQATuG8=",
+      "requires": {
+        "ethjs-format": "0.2.4",
+        "ethjs-rpc": "0.1.5"
+      }
+    },
+    "ethjs-rpc": {
+      "version": "0.1.5",
+      "resolved": "https://registry.npmjs.org/ethjs-rpc/-/ethjs-rpc-0.1.5.tgz",
+      "integrity": "sha1-CZ4i8n3EwYtpeKSF/DaxsPeWkIA="
+    },
+    "ethjs-schema": {
+      "version": "0.1.9",
+      "resolved": "https://registry.npmjs.org/ethjs-schema/-/ethjs-schema-0.1.9.tgz",
+      "integrity": "sha1-hYwqXacGrgSBK0zosetLSSHjMJI="
+    },
+    "ethjs-unit": {
+      "version": "0.1.6",
+      "resolved": "https://registry.npmjs.org/ethjs-unit/-/ethjs-unit-0.1.6.tgz",
+      "integrity": "sha1-xmWSHkduh7ziqdWIpv4EBbLEFpk=",
+      "requires": {
+        "bn.js": "4.11.6",
+        "number-to-bn": "1.7.0"
+      },
+      "dependencies": {
+        "bn.js": {
+          "version": "4.11.6",
+          "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.11.6.tgz",
+          "integrity": "sha1-UzRK2xRhehP26N0s4okF0cC6MhU="
+        }
+      }
+    },
+    "ethjs-util": {
+      "version": "0.1.3",
+      "resolved": "https://registry.npmjs.org/ethjs-util/-/ethjs-util-0.1.3.tgz",
+      "integrity": "sha1-39XqSkANxeQhqInK9H4IGtp4u1U=",
+      "requires": {
+        "is-hex-prefixed": "1.0.0",
+        "strip-hex-prefix": "1.0.0"
       }
     },
     "event-emitter": {

--- a/package.json
+++ b/package.json
@@ -42,6 +42,7 @@
   "dependencies": {
     "asmcrypto.js": "0.0.11",
     "bower": "^1.7.9",
+    "ethjs": "^0.3.0",
     "npm-run-all": "^4.1.1",
     "preact": "^8.2.1",
     "preact-compat": "^3.17.0",
@@ -52,8 +53,6 @@
     "ramda": "^0.25.0",
     "rimraf": "^2.5.2",
     "serve": "^5.2.4",
-    "truffle-contract": "^3.0.1",
-    "web3": "^0.20.2",
     "webpack-dev-server": "^2.7.1",
     "webpack-node-externals": "^1.5.4",
     "xhr2": "^0.1.3"

--- a/src/Lib/SignHash/Contracts.js
+++ b/src/Lib/SignHash/Contracts.js
@@ -1,48 +1,13 @@
 var R = require('ramda');
-var buildContract = require('truffle-contract');
 
 
-function requireABI (name) {
+function requireContractData (name) {
   return require('signhash-contracts/build/contracts/' + name + '.json');
 }
 
 
-var abis = R.map(requireABI, {
-  SignHash: 'SignHash',
-});
+exports.signerContractData = requireContractData('SignHash');
 
-
-function fixTruffleAPI(contract) {
-  // This rebinds `.call` of all contract methods to default
-  // `Function.prototype.call` implementation. Some environments /
-  // packages don't except .call to be rebound to a custom behavior
-  // and fail unexpectedly when working with `truffle-contract`
-  // (eg. testcafe and its hammerhead).
-  for (var i = 0; i < contract.abi.length; i++) {
-    var item = contract.abi[i];
-    if (item.type == "function") {
-      contract[item.name].call = Function.prototype.call;
-    }
-  }
-  return contract;
-}
-
-
-var getContract = R.curry(function (abi, web3) {
-  var contract = buildContract(abi);
-  contract.setProvider(web3.currentProvider);
-  return contract;
-});
-
-
-exports._getDeployed = function (contract) {
-  return function () {
-    return contract.deployed().then(fixTruffleAPI);
-  };
-};
-
-
-exports.loadSignerContract = getContract(abis.SignHash);
 
 exports._sign = R.curry(function(contract, checksum, address) {
   return function () {

--- a/src/Lib/SignHash/Contracts.purs
+++ b/src/Lib/SignHash/Contracts.purs
@@ -2,22 +2,26 @@ module Lib.SignHash.Contracts where
 
 import Prelude
 
-import Control.Monad.Aff (Aff, attempt)
+import Control.Monad.Aff (Aff, attempt, error)
 import Control.Monad.Eff (Eff)
 import Control.Monad.Eff.Exception (Error)
+import Control.Monad.Except (runExcept)
 import Control.Promise (Promise, toAffE)
 import Data.Array (head)
-import Data.Either (Either)
+import Data.Either (Either(..))
+import Data.Foreign (toForeign)
+import Data.Foreign.Index ((!))
 import Data.Maybe (maybe)
+import Debug.Trace (spy, traceA, traceAnyM)
 import FFI.Util (property)
-import FFI.Util.Function (callEff2)
+import FFI.Util.Function (call1, callEff2)
 import Lib.SignHash.Types (Checksum, HashSigner(..))
-import Lib.Web3 (Web3, WEB3)
+import Lib.Web3 (WEB3, Web3, bytesFromASCII)
 
 
 type Address = String
 
-newtype ContractABI t = ContractABI t
+newtype ContractData t = ContractData t
 
 class Contract c
 
@@ -29,25 +33,34 @@ prop :: forall a b. String -> a -> b
 prop = flip property
 
 
-foreign import _getDeployed ::
-  forall a eff.
-  ContractABI a ->
-  Eff (web3 :: WEB3 | eff) (Promise a)
-
-
 getDeployed ::
-  forall eff t. ContractABI t -> Aff (web3 :: WEB3 | eff) (Either Error t)
-getDeployed = attempt <<< toAffE <<< _getDeployed
+  forall eff t.
+  ContractData t ->
+  Web3 ->
+  Aff (web3 :: WEB3 | eff) (Either Error t)
+getDeployed contractData web3 = do
+  networkId <- toAffE (web3 `property` "net_version")
+
+  let address =
+        runExcept $
+        (toForeign contractData) ! "networks" ! networkId ! "address"
+
+  pure case address of
+    Left err -> Left $ error $ "Contract is not deployed to network id:"
+                <> networkId
+    Right value -> do
+      let contract = call1 web3 "contract" (contractData `property` "abi")
+      Right $ call1 contract "at" value
 
 
 foreign import data SignerContract :: Type
 instance _signerContract :: Contract SignerContract
 
-foreign import loadSignerContract :: Web3 -> ContractABI SignerContract
+foreign import signerContractData :: ContractData SignerContract
 
 signerContract ::
   forall eff. Web3 -> Aff (web3 :: WEB3 | eff) (Either Error SignerContract)
-signerContract = getDeployed <<< loadSignerContract
+signerContract = getDeployed signerContractData
 
 
 foreign import _sign ::
@@ -65,7 +78,7 @@ sign ::
   Address ->
   Aff (web3 :: WEB3 | eff) (Either Error Unit)
 sign contract checksum signer =
-  attempt $ toAffE $ _sign contract checksum signer
+  attempt $ toAffE $ _sign contract ("0x" <> checksum) signer
 
 
 getSigners ::
@@ -74,12 +87,16 @@ getSigners ::
   Checksum ->
   Int ->
   Aff (web3 :: WEB3 | eff) (Array String)
-getSigners contract checksum size =
-  toAffE $ callEff2 contract "getSigners" checksum size
-
+getSigners contract checksum size = do
+  value <- toAffE $ callEff2 contract "getSigners" ("0x" <> checksum) size
+  pure $ getResult value
 
 getSigner ::
   forall eff. SignerContract -> Checksum -> Aff (web3 :: WEB3 | eff) HashSigner
 getSigner contract checksum = do
   signers <- getSigners contract checksum 1
   pure $ maybe NoSigner HashSigner $ head signers
+
+
+getResult :: forall a b. a -> b
+getResult = prop "0"

--- a/src/Lib/Web3.js
+++ b/src/Lib/Web3.js
@@ -1,19 +1,17 @@
-var Web3 = require('web3');
-
-var web3Utils = new Web3();
+var Eth = require('ethjs');
 
 
-exports.bytesFromASCII = web3Utils.fromAscii;
+exports.bytesFromASCII = Eth.fromAscii;
 
 
 exports.buildWeb3 = function (config) {
-  return new Web3(new Web3.providers.HttpProvider(config));
+  return new Eth(new Eth.HttpProvider(config));
 };
 
 
 exports._getInjectedWeb3 = function() {
   if (typeof web3 !== 'undefined') {
-    return web3;
+    return new Eth(web3.currentProvider);
   } else {
     return undefined;
   }

--- a/src/Lib/Web3.purs
+++ b/src/Lib/Web3.purs
@@ -5,12 +5,12 @@ import Prelude
 import Control.Monad.Aff (Aff)
 import Control.Monad.Eff (Eff, kind Effect)
 import Control.Monad.Except (runExcept)
+import Control.Promise (toAffE)
 import DOM (DOM)
 import Data.Either (Either(..))
 import Data.Foreign (Foreign, readNullOrUndefined, unsafeFromForeign)
 import Data.Maybe (Maybe(..))
 import FFI.Util (property)
-import FFI.Util.Function (callAff0r1)
 import Lib.SignHash.Types (Address)
 
 
@@ -22,6 +22,7 @@ type Web3Aff eff res = Aff (web3 :: WEB3 | eff) res
 
 newtype Bytes = Bytes String
 
+foreign import bytesFromASCII :: String -> Bytes
 foreign import buildWeb3 :: Web3Config -> Web3
 foreign import _getInjectedWeb3 :: forall eff. Eff (dom :: DOM | eff) Foreign
 
@@ -44,12 +45,5 @@ getOrBuildWeb3 config = do
     Nothing -> buildWeb3 config
 
 
-foreign import bytesFromASCII :: String -> Bytes
-
-
 getAccounts :: forall eff. Web3 -> Web3Aff eff (Array Address)
-getAccounts web3 = callAff0r1 (web3 `property` "eth") "getAccounts"
-
-
-getBlockNumber :: forall eff. Web3 -> Web3Aff eff Int
-getBlockNumber web3 = callAff0r1 (web3 `property` "eth") "getBlockNumber"
+getAccounts web3 = toAffE (web3 `property` "accounts")


### PR DESCRIPTION
It saves ~300KB of ungzipped js, 50KBs gzipped. I don't feel it was worth that amount of work and I'm not sure it won't cause any problems in the future. At least it should be easy to rollback as I managed to keep the module API the same.

Closes #32 